### PR TITLE
Add a command to run a query in 'dry run' mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       },
       {
         "command": "extension.dryRun",
-        "title": "BigQuery: Dry run Query"
+        "title": "BigQuery: Run as Dry Run"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "activationEvents": [
     "onCommand:extension.runAsQuery",
-    "onCommand:extension.runSelectedAsQuery"
+    "onCommand:extension.runSelectedAsQuery",
+    "onCommand:extension.dryRun"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -29,6 +30,10 @@
       {
         "command": "extension.runSelectedAsQuery",
         "title": "BigQuery: Run selected text as Query"
+      },
+      {
+        "command": "extension.dryRun",
+        "title": "BigQuery: Dry run Query"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,13 +84,15 @@ function query(queryText: string, isDryRun?: boolean): Promise<any> {
     })
     .then(data => {
       let job = data[0];
+      id = job.id;
+      const jobIdMessage = `BigQuery job ID: ${job.id}`;
       if (isDryRun) {
-        vscode.window.showInformationMessage(
-            `BigQuery dry run successful. Job ID: ${job.id}`);
+        vscode.window.showInformationMessage(`${jobIdMessage} (dry run)`);
+        let totalBytesProcessed = job.metadata.statistics.totalBytesProcessed;
+        writeDryRunSummary(id, totalBytesProcessed);
         return null;
       }
-      id = job.id;
-      vscode.window.showInformationMessage(`BigQuery job ID: ${job.id}`);
+      vscode.window.showInformationMessage(jobIdMessage);
 
       return job.getQueryResults({
         autoPaginate: true
@@ -157,6 +159,13 @@ function writeResults(jobId: string, rows: Array<any>): void {
         );
       });
   }
+}
+
+function writeDryRunSummary(jobId: string, numBytesProcessed: string) {
+  output.show();
+  output.appendLine(`Results for job ${jobId} (dry run):`);
+  output.appendLine(`Total bytes processed: ${numBytesProcessed}`);
+  output.appendLine(``);
 }
 
 function getQueryText(


### PR DESCRIPTION
Show success or failure messages through the `showInformationMessage` toasts.